### PR TITLE
Revert "Run pipeline on PRs, but skip everything"

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -67,9 +67,6 @@ spec:
       description: Whether to enable privileged mode, should be used only with remote VMs
       name: privileged-nested
       type: string
-    - name: skip-everything
-      description: Skip every task. Required as a workaround for GitHub's handling of required status checks
-      type: string
   results:
     - description: ""
       name: IMAGE_URL
@@ -101,11 +98,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: clone-repository
       params:
         - name: url
@@ -130,10 +122,6 @@ spec:
       when:
         - input: $(tasks.init.results.build)
           operator: in
-          values:
-            - "true"
-        - input: $(params.skip-everything)
-          operator: notin
           values:
             - "true"
       workspaces:
@@ -165,11 +153,6 @@ spec:
           workspace: git-auth
         - name: netrc
           workspace: netrc
-      when:
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: build-container
       params:
         - name: IMAGE
@@ -215,10 +198,6 @@ spec:
           operator: in
           values:
             - "true"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: build-image-index
       params:
         - name: IMAGE
@@ -246,10 +225,6 @@ spec:
       when:
         - input: $(tasks.init.results.build)
           operator: in
-          values:
-            - "true"
-        - input: $(params.skip-everything)
-          operator: notin
           values:
             - "true"
     - name: build-source-image
@@ -282,10 +257,6 @@ spec:
           operator: in
           values:
             - "true"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: deprecated-base-image-check
       params:
         - name: IMAGE_URL
@@ -308,10 +279,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: clair-scan
       params:
         - name: image-digest
@@ -334,10 +301,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: sast-snyk-check
       params:
         - name: image-digest
@@ -364,10 +327,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: clamav-scan
       params:
         - name: image-digest
@@ -390,10 +349,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: sast-coverity-check
       params:
         - name: image-digest
@@ -443,10 +398,6 @@ spec:
           operator: in
           values:
             - success
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: coverity-availability-check
       runAfter:
         - build-image-index
@@ -464,10 +415,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: sast-shell-check
       params:
         - name: image-digest
@@ -494,10 +441,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: sast-unicode-check
       params:
         - name: image-digest
@@ -524,10 +467,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: apply-tags
       params:
         - name: IMAGE_URL
@@ -545,11 +484,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: push-dockerfile
       params:
         - name: IMAGE
@@ -573,11 +507,6 @@ spec:
           - name: kind
             value: task
         resolver: bundles
-      when:
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
     - name: rpms-signature-scan
       params:
         - name: image-url
@@ -600,10 +529,6 @@ spec:
           operator: in
           values:
             - "false"
-        - input: $(params.skip-everything)
-          operator: notin
-          values:
-            - "true"
   workspaces:
     - name: git-auth
       optional: true

--- a/.tekton/merge-queue-test-enter-merge-queue.yaml
+++ b/.tekton/merge-queue-test-enter-merge-queue.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: |
-      event == "pull_request" ||
-      (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: merge-queue-test
@@ -29,8 +27,6 @@ spec:
     value: Containerfile
   - name: path-context
     value: .
-  - name: skip-everything
-    value: 'false'
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
This reverts commit 40ea0adb0b7879eb8dedabc6676e48bdc3ad8e80.

Skipping all tasks isn't really a solution, since it breaks Snapshot
creation and therefore breaks IntegrationTestScenarios

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
